### PR TITLE
build: add bumpp config to keep README version in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Create a file named drillbit.toml in your project's directory.
 
 ```toml
 [plugins.jest_roblox]
-github = "https://github.com/christopher-buss/jest-roblox-cli/releases/download/v0.2.1/JestRobloxRunner.rbxm"
+github = "https://github.com/christopher-buss/jest-roblox-cli/releases/download/v0.2.3/JestRobloxRunner.rbxm"
 ```
 
 Then run `drillbit` and it will download the plugin and install it in Studio for you.

--- a/bump.config.ts
+++ b/bump.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "bumpp";
+
+export default defineConfig({
+	files: ["package.json", "README.md"],
+});

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -20,9 +20,7 @@
 		"src/**/*.spec.tsx",
 		"test/**/*.*",
 		"loaders/**/*.d.mts",
-		"eslint.config.ts",
-		"tsdown.config.ts",
-		"vitest.config.ts"
+		"*.config.ts"
 	],
 	"exclude": ["${configDir}/node_modules", "**/fixtures/"]
 }


### PR DESCRIPTION
## Summary
- Add `bump.config.ts` with `files: ['package.json', 'README.md']` so `pnpm release` rewrites the drillbit plugin URL alongside `package.json`.
- Sync README plugin URL from `v0.2.1` → `v0.2.3` (the current `package.json` version) so bumpp's text matcher finds the literal on the next bump — bumpp's `updateTextFile` requires the current version to appear verbatim in the file before it will rewrite.
- Broaden `tsconfig.spec.json` include from a hardcoded config list to `*.config.ts` (lint fix).

## Test plan
- [ ] `pnpm release` dry-run rewrites both `package.json` and the README URL
- [ ] `pnpm lint` / `pnpm typecheck` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin configuration example to reference a newer release version.

* **Chores**
  * Added and updated configuration files for build and TypeScript tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->