### PR TITLE
Fix Studio Backend Incorrectly Handling Non-Jest Error

### DIFF
--- a/src/backends/envelope.ts
+++ b/src/backends/envelope.ts
@@ -18,8 +18,9 @@ const envelopeSchema = type({
 export function parseEnvelope(jestOutput: string): Array<EnvelopeEntry> {
 	const raw = JSON.parse(jestOutput);
 	const envelope = envelopeSchema(raw);
+
 	if (envelope instanceof type.errors) {
-		return [{ jestOutput }];
+		throw new Error(jestOutput);
 	}
 
 	return envelope.entries;


### PR DESCRIPTION
If there is an error in the studio backend, that is not from Jest's output, we currently get an error that is not useful. I've chosen to throw here as I don't think it's worth trying to put the error into a format that the rest of the program can use.

### Before
`Error: Studio backend returned 1 entries but request had 5 jobs`

### After
`Error: {"success":false,"err":"LoadString must be enabled in ServerScriptService to run tests"}`