### PR TITLE
fix: stop a nested coverage spine building duplicate folders

### DIFF
--- a/src/coverage-pipeline/prepare.spec.ts
+++ b/src/coverage-pipeline/prepare.spec.ts
@@ -3325,6 +3325,46 @@ describe("narrowing to the coverage universe", () => {
 		).toBeTrue();
 	});
 
+	it("should refill a spine leaf a warm run recorded elsewhere", async () => {
+		expect.assertions(2);
+
+		seedNarrowableRoot();
+		const { buildWithRojo } = await setupMocksAsync();
+		const config = makeConfig({
+			collectCoverageFrom: ["**/ecs/**"],
+			luauRoots: ["out"],
+			rootDir: process.cwd(),
+		});
+
+		prepareCoverage(config);
+		// Rewind the shadow to the shape the nested-spine layout left: each
+		// level's files directly under its mirror, and a manifest recording
+		// them there.
+		const mirrored = [
+			{ name: "loose.luau", level: "out" },
+			{ name: "net.luau", level: "out/modules" },
+		];
+		for (const { name, level } of mirrored) {
+			const leaf = `.jest-roblox/coverage/.spine/${level}/.self`;
+			vol.renameSync(`${leaf}/${name}`, `.jest-roblox/coverage/.spine/${level}/${name}`);
+			vol.rmdirSync(leaf);
+		}
+
+		const manifestPath = ".jest-roblox/coverage/coverage-manifest.json";
+		vol.writeFileSync(
+			manifestPath,
+			String(vol.readFileSync(manifestPath)).replaceAll("/.self/", "/"),
+		);
+
+		prepareCoverage(config);
+
+		// Carrying those records forward would leave every mounted leaf empty,
+		// so the place would build each demoted level without its own files —
+		// and, seeing no change, hand back the place that already had.
+		expect(vol.existsSync(".jest-roblox/coverage/.spine/out/.self/loose.luau")).toBeTrue();
+		expect(buildWithRojo).toHaveBeenCalledTimes(2);
+	});
+
 	it("should record the narrowed roots in the manifest", async () => {
 		expect.assertions(1);
 

--- a/src/coverage-pipeline/prepare.spec.ts
+++ b/src/coverage-pipeline/prepare.spec.ts
@@ -3319,8 +3319,10 @@ describe("narrowing to the coverage universe", () => {
 
 		prepareCoverage(config);
 
-		expect(vol.existsSync(".jest-roblox/coverage/.spine/out/loose.luau")).toBeTrue();
-		expect(vol.existsSync(".jest-roblox/coverage/.spine/out/modules/net.luau")).toBeTrue();
+		expect(vol.existsSync(".jest-roblox/coverage/.spine/out/.self/loose.luau")).toBeTrue();
+		expect(
+			vol.existsSync(".jest-roblox/coverage/.spine/out/modules/.self/net.luau"),
+		).toBeTrue();
 	});
 
 	it("should record the narrowed roots in the manifest", async () => {
@@ -3377,7 +3379,7 @@ describe("narrowing to the coverage universe", () => {
 
 		// The place mounts the spine in `out`'s place, so anything baked into
 		// the mirror would never reach it.
-		expect(layouts[0]!.mountedDirectory("out")).toBe(".jest-roblox/coverage/.spine/out");
+		expect(layouts[0]!.mountedDirectory("out")).toBe(".jest-roblox/coverage/.spine/out/.self");
 		expect(layouts[0]!.mountedDirectory("out/modules/ecs")).toBe(
 			".jest-roblox/coverage/out/modules/ecs",
 		);

--- a/src/coverage-pipeline/shadow-root.ts
+++ b/src/coverage-pipeline/shadow-root.ts
@@ -229,10 +229,12 @@ const COV_MAP_SUFFIX = ".cov-map.json";
 /**
  * Mirror one file into the shadow, or carry its previous record forward.
  *
- * The carry-forward wants both a matching source hash AND a file still at the
- * path the record points at: a partial cleanup or an interrupted run can leave
- * the record valid on paper while the file it names is gone — or replaced by a
- * directory, which is the same lie told the other way round.
+ * The carry-forward wants a matching source hash AND a record naming the very
+ * path this call would write AND a file still there: a partial cleanup or an
+ * interrupted run can leave the record valid on paper while the file it names
+ * is gone — or replaced by a directory, which is the same lie told the other
+ * way round — and a record from a run that mirrored this file somewhere else
+ * proves nothing about the path we mirror it to now.
  *
  * One read serves both jobs. The hash decides whether the copy is needed, and
  * when it is, the bytes are already in hand — `copyFileSync` would open and
@@ -251,7 +253,11 @@ export function syncOneFile(
 ): NonInstrumentedFileRecord {
 	const contents = fs.readFileSync(path.resolve(sourcePath));
 	const currentHash = hashBuffer(contents);
-	if (previousRecord?.sourceHash === currentHash && shadowHoldsFile(previousRecord.shadowPath)) {
+	if (
+		previousRecord?.sourceHash === currentHash &&
+		previousRecord.shadowPath === shadowPath &&
+		shadowHoldsFile(shadowPath)
+	) {
 		return previousRecord;
 	}
 

--- a/src/coverage-pipeline/spine.spec.ts
+++ b/src/coverage-pipeline/spine.spec.ts
@@ -18,6 +18,11 @@ const REPO = normalizeWindowsPath(path.resolve("/repo"));
 const SHADOW = `${REPO}/.jest-roblox/coverage`;
 const SPINE = `${SHADOW}/.spine`;
 
+/** The copy the place mounts in one demoted level's stead. */
+function mounted(level: string): string {
+	return `${SPINE}/${level}/.self`;
+}
+
 const NO_COPY_IGNORE = createCopyIgnoreMatcher([]);
 
 const OUT = normalizeWindowsPath(path.resolve("/repo/out"));
@@ -124,9 +129,29 @@ describe(prepareSpine, () => {
 
 		spineOf(["out/server", "out/server/modules"]);
 
-		expect(vol.existsSync(`${SPINE}/out/server/loose.luau`)).toBeTrue();
-		expect(vol.existsSync(`${SPINE}/out/server/modules/net.luau`)).toBeTrue();
-		expect(vol.existsSync(`${SPINE}/out/server/modules/ecs`)).toBeFalse();
+		expect(vol.existsSync(`${mounted("out/server")}/loose.luau`)).toBeTrue();
+		expect(vol.existsSync(`${mounted("out/server/modules")}/net.luau`)).toBeTrue();
+		expect(vol.existsSync(`${mounted("out/server/modules")}/ecs`)).toBeFalse();
+	});
+
+	it("should keep a deeper spine level outside the level above it", () => {
+		expect.assertions(4);
+
+		seed({
+			[at("server/loose.luau")]: "return nil",
+			[at("server/modules/net.luau")]: "return nil",
+		});
+
+		const [above, below] = spineOf(["out/server", "out/server/modules"]).directories;
+
+		// Rojo mounts a directory whole. A mount that physically held the level
+		// below it would serve that level twice — once through this `$path`,
+		// once through the explicit child the demote hangs beside it — and the
+		// place would carry two Instances of the same name.
+		expect(below!.shadowDir.startsWith(`${above!.shadowDir}/`)).toBeFalse();
+		expect(vol.readdirSync(above!.shadowDir)).toStrictEqual(["loose.luau"]);
+		expect(vol.existsSync(`${above!.shadowDir}/loose.luau`)).toBeTrue();
+		expect(vol.existsSync(`${below!.shadowDir}/net.luau`)).toBeTrue();
 	});
 
 	it("should name the copy the place mounts for each demoted level", () => {
@@ -135,7 +160,7 @@ describe(prepareSpine, () => {
 		seed({ [at("server/loose.luau")]: "return nil" });
 
 		expect(spineOf(["out/server"]).directories).toStrictEqual([
-			{ luauRoot: "out/server", shadowDir: `${SPINE}/out/server` },
+			{ luauRoot: "out/server", shadowDir: mounted("out/server") },
 		]);
 	});
 
@@ -162,7 +187,7 @@ describe(prepareSpine, () => {
 			isCopyIgnored: createCopyIgnoreMatcher(["skip.luau.map"]),
 		});
 
-		expect(vol.existsSync(`${SPINE}/out/server/skip.luau.map`)).toBeFalse();
+		expect(vol.existsSync(`${mounted("out/server")}/skip.luau.map`)).toBeFalse();
 		expect(Object.keys(result.files)).toStrictEqual([at("server/keep.luau")]);
 	});
 
@@ -204,7 +229,7 @@ describe(prepareSpine, () => {
 		vol.unlinkSync(at("server/loose.luau"));
 		const result = spineOf(["out/server"]);
 
-		expect(vol.existsSync(`${SPINE}/out/server/loose.luau`)).toBeFalse();
+		expect(vol.existsSync(`${mounted("out/server")}/loose.luau`)).toBeFalse();
 		expect(result.changed).toBeTrue();
 	});
 });

--- a/src/coverage-pipeline/spine.spec.ts
+++ b/src/coverage-pipeline/spine.spec.ts
@@ -135,7 +135,7 @@ describe(prepareSpine, () => {
 	});
 
 	it("should keep a deeper spine level outside the level above it", () => {
-		expect.assertions(4);
+		expect.assertions(3);
 
 		seed({
 			[at("server/loose.luau")]: "return nil",
@@ -150,7 +150,6 @@ describe(prepareSpine, () => {
 		// place would carry two Instances of the same name.
 		expect(below!.shadowDir.startsWith(`${above!.shadowDir}/`)).toBeFalse();
 		expect(vol.readdirSync(above!.shadowDir)).toStrictEqual(["loose.luau"]);
-		expect(vol.existsSync(`${above!.shadowDir}/loose.luau`)).toBeTrue();
 		expect(vol.existsSync(`${below!.shadowDir}/net.luau`)).toBeTrue();
 	});
 

--- a/src/coverage-pipeline/spine.ts
+++ b/src/coverage-pipeline/spine.ts
@@ -18,6 +18,20 @@ import { syncOneFile, tryRemove } from "./shadow-root.ts";
 const SPINE_DIR = ".spine";
 
 /**
+ * The directory a spine level's own files actually sit in, one below the
+ * mirror of its source path.
+ *
+ * Rojo mounts a directory whole, so a level's mount may not contain the level
+ * below it: the demote hangs that one off an explicit child as well, and rojo
+ * would build both into same-named Instances. The leaf breaks that up — two
+ * levels on one chain mirror to `<a>/.self` and `<a>/<b>/.self`, which are
+ * siblings rather than nested. Dot-prefixed so no source directory can ever
+ * claim the name: the coverage walk skips a dot-prefixed directory, so nothing
+ * under one is ever a coverage root, and a spine level is an ancestor of one.
+ */
+const SPINE_LEAF = ".self";
+
+/**
  * Where the built place reads each source directory from, for a caller that
  * bakes files into the shadow before the build.
  *
@@ -218,19 +232,23 @@ function containingMount(root: string, mounts: ReadonlySet<string>): string | un
 
 /** The shadow copy that stands in for one demoted source directory. */
 function toSpineDirectory(shadowRoot: string, relativePath: string): string {
-	return normalizeWindowsPath(path.join(shadowRoot, SPINE_DIR, relativePath));
+	return normalizeWindowsPath(path.join(shadowRoot, SPINE_DIR, relativePath, SPINE_LEAF));
 }
 
 /**
- * Drop every spine file this pass did not mirror. Nothing else reconciles
+ * Drop every spine entry this pass did not mirror. Nothing else reconciles
  * these — the per-root walk starts below them — so a source file deleted
  * between runs would otherwise keep loading from the place.
+ *
+ * Files are all there is to find: only the mirror and the stub bake write into
+ * a spine leaf, and the leaf is where the layout puts a level's loose files
+ * precisely so that nothing nests underneath it.
  */
 function pruneSpineDirectory(spineDirectory: string, mirrored: ReadonlySet<string>): boolean {
 	let hasDeleted = false;
 	const entries = fs.readdirSync(spineDirectory, { withFileTypes: true });
 	for (const entry of entries) {
-		if (entry.isDirectory() || mirrored.has(entry.name)) {
+		if (mirrored.has(entry.name)) {
 			continue;
 		}
 

--- a/src/coverage-pipeline/spine.ts
+++ b/src/coverage-pipeline/spine.ts
@@ -24,10 +24,12 @@ const SPINE_DIR = ".spine";
  * Rojo mounts a directory whole, so a level's mount may not contain the level
  * below it: the demote hangs that one off an explicit child as well, and rojo
  * would build both into same-named Instances. The leaf breaks that up — two
- * levels on one chain mirror to `<a>/.self` and `<a>/<b>/.self`, which are
- * siblings rather than nested. Dot-prefixed so no source directory can ever
- * claim the name: the coverage walk skips a dot-prefixed directory, so nothing
- * under one is ever a coverage root, and a spine level is an ancestor of one.
+ * levels on one chain mirror to `<a>/.self` and `<a>/<b>/.self`, siblings
+ * rather than one inside the other.
+ *
+ * Which holds as long as `<b>` is never `.self`, and dot-prefixing is what
+ * buys that: every level below the mount is a directory the coverage walk
+ * descended to reach a root, and that walk passes over a dot-prefixed name.
  */
 const SPINE_LEAF = ".self";
 

--- a/src/coverage-pipeline/workspace-prepare.spec.ts
+++ b/src/coverage-pipeline/workspace-prepare.spec.ts
@@ -2613,7 +2613,7 @@ describe("narrowing a workspace package to its coverage universe", () => {
 			vol.existsSync(
 				path.join(
 					WORKSPACE_ROOT,
-					".jest-roblox/workspace/@halcyon-foo/coverage/.spine/out/loose.luau",
+					".jest-roblox/workspace/@halcyon-foo/coverage/.spine/out/.self/loose.luau",
 				),
 			),
 		).toBeTrue();

--- a/test/synthesizer-rojo-build.integration.spec.ts
+++ b/test/synthesizer-rojo-build.integration.spec.ts
@@ -1,10 +1,14 @@
+import { scope } from "arktype";
 import * as cp from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, expect, it, onTestFinished } from "vitest";
 
+import { createCopyIgnoreMatcher } from "../src/coverage-pipeline/discover-files.ts";
+import { prepareSpine, resolveSpineDirectories } from "../src/coverage-pipeline/spine.ts";
 import { synthesize } from "../src/staging/synthesizer.ts";
+import { normalizeWindowsPath } from "../src/utils/normalize-windows-path.ts";
 import { buildWithRojo } from "../src/utils/rojo-builder.ts";
 
 function rojoOnPath(): boolean {
@@ -22,6 +26,50 @@ function createTemporaryDirectory(): string {
 		fs.rmSync(directory, { force: true, recursive: true });
 	});
 	return directory;
+}
+
+// A scope rather than a bare `type`, because the node refers to itself and
+// only an alias can carry that.
+const sourcemapNodeSchema = scope({
+	sourcemapNode: {
+		"name": "string",
+		"children?": "sourcemapNode[]",
+	},
+}).export().sourcemapNode;
+
+type SourcemapNode = typeof sourcemapNodeSchema.infer;
+
+/**
+ * What rojo would build, read without building it. `sourcemap` names every
+ * Instance the project resolves to, and `--include-non-scripts` is what makes
+ * the Folders a duplicate mount shows up as visible.
+ */
+function readSourcemap(projectPath: string): SourcemapNode {
+	// `--absolute` because the synthesized project sits in `.jest-roblox` while
+	// its `$path`s point back at the packages, and rojo cannot express one
+	// relative to the other.
+	const output = cp.execFileSync(
+		"rojo",
+		["sourcemap", projectPath, "--absolute", "--include-non-scripts"],
+		{ encoding: "utf-8", windowsHide: true },
+	);
+	return sourcemapNodeSchema.assert(JSON.parse(output));
+}
+
+/** Every Instance in the tree carrying `name`, however deep. */
+function namedNodes(node: SourcemapNode, name: string): Array<SourcemapNode> {
+	const found = node.name === name ? [node] : [];
+	const children = node.children ?? [];
+	for (const child of children) {
+		found.push(...namedNodes(child, name));
+	}
+
+	return found;
+}
+
+function childNames(node: SourcemapNode | undefined): Array<string> {
+	const children = node?.children ?? [];
+	return children.map((child) => child.name);
 }
 
 describe("synthesizer + rojo build integration", () => {
@@ -65,6 +113,106 @@ describe("synthesizer + rojo build integration", () => {
 
 			expect(fs.existsSync(synthRbxlPath)).toBeTrue();
 			expect(fs.statSync(synthRbxlPath).size).toBeGreaterThan(0);
+		},
+	);
+
+	it.skipIf(!rojoOnPath())(
+		"should build one Instance per directory when a coverage spine nests",
+		() => {
+			expect.assertions(4);
+
+			const workspace = createTemporaryDirectory();
+			const packageDirectory = path.join(workspace, "packages/foo");
+			function write(relativePath: string, contents: string): void {
+				const absolute = path.join(packageDirectory, relativePath);
+				fs.mkdirSync(path.dirname(absolute), { recursive: true });
+				fs.writeFileSync(absolute, contents);
+			}
+
+			// One covered root, three levels below the mount, with a loose file
+			// and an uncovered sibling at each level on the way down.
+			write("out/loose.luau", "return {}\n");
+			write("out/shared/log-config.luau", "return {}\n");
+			write("out/shared/modules/net.luau", "return {}\n");
+			write("out/shared/modules/utilities/helper.luau", "return {}\n");
+			write("out/shared/modules/ecs/world.luau", "return {}\n");
+			write(
+				"test.project.json",
+				JSON.stringify({
+					name: "foo-test",
+					tree: {
+						$className: "DataModel",
+						ReplicatedStorage: { $className: "ReplicatedStorage", $path: "out" },
+					},
+				}),
+			);
+
+			const shadowRoot = normalizeWindowsPath(path.join(workspace, ".jest-roblox/coverage"));
+			const shadowDirectory = `${shadowRoot}/out/shared/modules/ecs`;
+			fs.mkdirSync(shadowDirectory, { recursive: true });
+			fs.writeFileSync(
+				path.join(shadowDirectory, "world.luau"),
+				"-- instrumented\nreturn {}\n",
+			);
+
+			// The layout under test: the real spine pass decides where each
+			// demoted level's own files land, and synthesis mounts exactly what
+			// it names.
+			const spine = prepareSpine({
+				isCopyIgnored: createCopyIgnoreMatcher([]),
+				narrowed: [
+					{
+						luauRoot: "out",
+						roots: ["out/shared/modules/ecs"],
+						spine: resolveSpineDirectories(
+							["out/shared/modules/ecs"],
+							new Set(["out"]),
+						),
+					},
+				],
+				previousNonInstrumented: undefined,
+				shadowRoot,
+				toSourcePath: (relativePath) => {
+					return normalizeWindowsPath(path.join(packageDirectory, relativePath));
+				},
+			});
+
+			const synthesized = synthesize({
+				packages: [
+					{
+						name: "@halcyon/foo",
+						coverageRoots: [
+							{ luauRoot: "out/shared/modules/ecs", shadowDir: shadowDirectory },
+						],
+						coverageSpine: spine.directories,
+						packageDirectory,
+						rojoProjectPath: path.join(packageDirectory, "test.project.json"),
+					},
+				],
+			});
+
+			const synthDirectory = path.join(workspace, ".jest-roblox/workspace");
+			fs.mkdirSync(synthDirectory, { recursive: true });
+			const synthProjectPath = path.join(synthDirectory, "synthesized.project.json");
+			fs.writeFileSync(synthProjectPath, synthesized);
+
+			const root = readSourcemap(synthProjectPath);
+
+			// A spine level whose mount still contained the level below it would
+			// build that level twice — once auto-mounted through the `$path`,
+			// once as the explicit child the demote hangs beside it — and
+			// whichever copy a require resolved first decided what it could see.
+			expect(namedNodes(root, "modules")).toHaveLength(1);
+			expect(childNames(namedNodes(root, "modules")[0])).toIncludeSameMembers([
+				"ecs",
+				"net",
+				"utilities",
+			]);
+			expect(namedNodes(root, "shared")).toHaveLength(1);
+			expect(childNames(namedNodes(root, "shared")[0])).toIncludeSameMembers([
+				"log-config",
+				"modules",
+			]);
 		},
 	);
 });


### PR DESCRIPTION
## Problem

`--coverage` on a workspace whose covered roots sit two or more levels below a rojo `$path` mount built a place with duplicate folders. In Anime Rush, `ReplicatedStorage.shared.modules` existed twice — one complete, one holding only the compiled `log-config`. RuntimeLib resolved the incomplete copy, so `WaitForChild("utilities")` never returned and the run died with `DEADLINE_EXCEEDED`. `--no-coverage` passed.

## Cause

`d36d239` mirrored each demoted spine level at its own source-relative path, so two levels on one chain landed one physically inside the other:

```
.spine/out/shared/            <- mounted for `shared`
.spine/out/shared/modules/    <- mounted for `shared.modules`
```

Rojo mounts a directory whole, so `shared`'s `$path` auto-mounted `modules`, while the demote also hangs `modules` beside it as an explicit child. Two Instances, same name.

## Fix

Every level's own files now live in a `.self` leaf below the mirror, so two levels are siblings rather than nested. Dot-prefixed for a reason that holds: every level below the mount is a directory the coverage walk descended to reach a root, and that walk passes over dot-prefixed names — so no level can be named `.self`.

A second commit fixes the upgrade path. `syncOneFile` asked whether a file was still at the path the previous record named, never whether that was the path this run mirrors to, so a layout change read as "nothing to do": the leaf stayed empty and the run reused the place the old layout had built. Warm shadows now heal themselves instead of needing a manual `.jest-roblox` wipe.

## Tests

The existing synthesizer specs assert the project JSON, which looked plausible the whole time the place carried three `modules` folders. The new `test/synthesizer-rojo-build.integration.spec.ts` case runs the real spine pass and real rojo, then reads the sourcemap back: one Instance per source directory, each holding both its loose files and its explicit children. Reverting `toSpineDirectory` alone turns it red (3 `modules` Instances).

## Verification

- `vitest run --coverage` — 3743 passed, 100% statements/branches/functions/lines.
- `eslint` — clean.
- Anime Rush, the narrowed repro that used to hang: 6 passed.
- Anime Rush, full `--workspace`: 635 files, 6210 tests, all passed.
- `rojo sourcemap` on the synthesized place shows exactly one `shared/modules`, containing both `utilities` and `log-config`.

Not added: an end-to-end fixture that requires a non-covered sibling through a demoted parent. The deterministic e2e harness stubs Open Cloud, so it would prove no more than the sourcemap test does, and the live-gated project needs credentials this branch cannot exercise — the runtime path was verified against the real Anime Rush repro instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
