### PR TITLE
fix: make a workspace failure that captured no cause say what it knows

### DIFF
--- a/luau/process-capture.luau
+++ b/luau/process-capture.luau
@@ -1,0 +1,45 @@
+--!strict
+-- Installs the stdout/stderr tap both runners read their Banner Output from:
+-- `runner.luau` (multi) and `staging/embedded-runner.luau` (workspace). Jest
+-- writes its exit-time messages ("No tests found, exiting with code 1") through
+-- `process.stdout`, and a run that loses this tap reports an exit code with no
+-- cause attached to it.
+
+local InstanceResolver = require("./instance-resolver")
+local InterceptWriteable = require("./intercept-writeable")
+
+type CapturedMessage = InterceptWriteable.CapturedMessage
+
+local module = {}
+
+--[=[
+	Tap `process.stdout` and `process.stderr` into `buffer` for the length of a
+	run. Returns the thunk restoring both, or nil when the tap could not be
+	installed.
+
+	RobloxShared is resolved through the same walk snapshot support uses rather
+	than through a fixed hop up the Jest module's ancestors: how deep the two
+	packages sit under each other depends on how the consumer's tree mounts
+	node_modules, and getting it wrong here costs the run its Banner Output
+	without failing anything the reader would notice.
+]=]
+function module.install(jestModule: ModuleScript, buffer: { CapturedMessage }): (() -> ())?
+	local ok, restore = pcall(function(): () -> ()
+		local sharedInstance = InstanceResolver.findRobloxShared(jestModule)
+		assert(sharedInstance, "Could not find RobloxShared")
+
+		local RobloxShared = (require :: any)(sharedInstance)
+		local process = RobloxShared.nodeUtils.process
+		local restoreStdout = InterceptWriteable.intercept(process.stdout, buffer, 0)
+		local restoreStderr = InterceptWriteable.intercept(process.stderr, buffer, 1)
+
+		return function()
+			restoreStdout()
+			restoreStderr()
+		end
+	end)
+
+	return if ok then restore else nil
+end
+
+return module

--- a/luau/runner-result.luau
+++ b/luau/runner-result.luau
@@ -59,17 +59,30 @@ export type Dimensions = {
 ]=]
 export type Abandon = "timeout"
 
+--[=[
+	How far a run got before it failed.
+
+	A string rather than a union of the phases each runner names: the two split
+	their work differently, and the host renders a phase it has no wording for
+	as itself, so a runner naming a new one costs nothing on either side.
+]=]
+export type Phase = string
+
 -- What a runner measured about a run that produced no result. Same
--- empty-is-absent rule as `Dimensions`: a failure the runner did not abandon
+-- empty-is-absent rule as `Dimensions`: a failure that measured none of these
 -- passes nothing and the envelope grows no `runner` block.
 export type FailureDimensions = {
 	abandon: Abandon?,
+	captureInstalled: boolean?,
+	phase: Phase?,
 }
 
 export type RunnerFields = {
 	abandon: Abandon?,
+	captureInstalled: boolean?,
 	coverage: { [string]: any }?,
 	perTestCoverage: { PerTestCoverage.Record }?,
+	phase: Phase?,
 	setup: number?,
 	snapshotWrites: { [string]: string }?,
 	timing: { [string]: number }?,
@@ -295,10 +308,11 @@ end
 	Assemble the envelope a runner returns for a run that produced no result.
 
 	`build`'s other half, and here for the same reason: a dimension only a
-	failed run can carry — why the run was given up on — otherwise has no seam
-	to land on, and gets plumbed per runner and then again across the wire as a
-	field of its own. Kept beside `build` so both halves put a runner's fields
-	under the same `runner` key, and the host reads them in one place.
+	failed run can carry — why the run was given up on, how far it got, whether
+	its output was being watched — otherwise has no seam to land on, and gets
+	plumbed per runner and then again across the wire as a field of its own.
+	Kept beside `build` so both halves put a runner's fields under the same
+	`runner` key, and the host reads them in one place.
 ]=]
 function module.fail(err: any, dimensions: FailureDimensions?): Payload
 	local payload: Payload = {
@@ -306,9 +320,20 @@ function module.fail(err: any, dimensions: FailureDimensions?): Payload
 		success = false,
 	}
 
-	local abandon = if dimensions then dimensions.abandon else nil
-	if abandon ~= nil then
-		payload.runner = { abandon = abandon }
+	if dimensions == nil then
+		return payload
+	end
+
+	-- Built by assignment rather than field by field: a nil in a table
+	-- constructor makes no key, so the same table both carries what the run
+	-- measured and answers whether it measured anything at all.
+	local fields: RunnerFields = {
+		abandon = dimensions.abandon,
+		captureInstalled = dimensions.captureInstalled,
+		phase = dimensions.phase,
+	}
+	if next(fields :: any) then
+		payload.runner = fields
 	end
 
 	return payload

--- a/luau/runner.luau
+++ b/luau/runner.luau
@@ -6,6 +6,7 @@ local InfiniteYield = require("./infinite-yield")
 local InstanceResolver = require("./instance-resolver")
 local InterceptWriteable = require("./intercept-writeable")
 local PhaseTiming = require("./phase-timing")
+local ProcessCapture = require("./process-capture")
 local PromiseError = require("./promise-error")
 local RunnerResult = require("./runner-result")
 local SetupTiming = require("./setup-timing")
@@ -72,12 +73,19 @@ function module.run(
 		return (if stopCapture then stopCapture() else nil) or "[]"
 	end
 
+	-- How far this run got, for a failure that comes back with nothing else to
+	-- say. Read on every failure path below, and by `runTests` as it passes
+	-- each boundary.
+	local phase = "resolveJest"
+
 	local t_findJest0 = os.clock()
 	local findSuccess, findValue = pcall(InstanceResolver.getJest, config)
 	local t_findJest = os.clock()
 
 	if not findSuccess then
-		return HttpService:JSONEncode(RunnerResult.fail(findValue)), encodeGameOutput(), "[]"
+		return HttpService:JSONEncode(RunnerResult.fail(findValue, { phase = phase })),
+			encodeGameOutput(),
+			"[]"
 	end
 
 	local snapshotWrites: { [string]: string } = {}
@@ -98,26 +106,12 @@ function module.run(
 	-- Game Output above: this narrower buffer is what the CLI's error
 	-- banner reads on Luau errors (see cli.ts:formatLuauErrorBanner).
 	local capturedMessages: { CapturedMessage } = {}
-	local restoreStdout: (() -> ())?
-	local restoreStderr: (() -> ())?
-
-	local interceptOk = pcall(function()
-		local nodeModules = findValue.Parent.Parent.Parent :: any
-		local RobloxShared = (require :: any)(nodeModules["@rbxts-js"].RobloxShared)
-		local process = RobloxShared.nodeUtils.process
-
-		restoreStdout = InterceptWriteable.intercept(process.stdout, capturedMessages, 0)
-		restoreStderr = InterceptWriteable.intercept(process.stderr, capturedMessages, 1)
-	end)
-
-	if not interceptOk then
-		restoreStdout = nil
-		restoreStderr = nil
-	end
+	local restoreCapture = ProcessCapture.install(findValue, capturedMessages)
 
 	local pending: any = nil
 
 	local function runTests()
+		phase = "resolveProjects"
 		local t_resolveProjects0 = os.clock()
 		local projects = {}
 
@@ -164,6 +158,7 @@ function module.run(
 		config.runnerTimeoutMs = nil :: any
 		config.runnerCaptureGameOutput = nil :: any
 
+		phase = "run"
 		local coverage = RunnerResult.beginCoverage(findValue, {
 			coverage = coverageEnabled,
 			perTest = perTestEnabled,
@@ -220,12 +215,8 @@ function module.run(
 		timeoutMs = budgetMs,
 	})
 
-	if restoreStdout then
-		restoreStdout()
-	end
-
-	if restoreStderr then
-		restoreStderr()
+	if restoreCapture then
+		restoreCapture()
 	end
 
 	SnapshotPatch.unpatch(patchState)
@@ -233,7 +224,11 @@ function module.run(
 	local jestResult
 	if not runSuccess then
 		jestResult = HttpService:JSONEncode(
-			RunnerResult.fail(runValue, { abandon = if timedOut then "timeout" else nil })
+			RunnerResult.fail(runValue, {
+				abandon = if timedOut then "timeout" else nil,
+				captureInstalled = restoreCapture ~= nil,
+				phase = phase,
+			})
 		)
 	else
 		jestResult = HttpService:JSONEncode(runValue)

--- a/luau/staging/embedded-runner.luau
+++ b/luau/staging/embedded-runner.luau
@@ -15,6 +15,7 @@ local InstanceResolver = require("../instance-resolver")
 local InterceptWriteable = require("../intercept-writeable")
 local Materializer = require("./materializer")
 local PhaseTiming = require("../phase-timing")
+local ProcessCapture = require("../process-capture")
 local PromiseError = require("../promise-error")
 local ResultBudget = require("./result-budget")
 local RunnerResult = require("../runner-result")
@@ -138,6 +139,20 @@ export type ResultEntry = {
 	bannerOutput: string?,
 }
 
+--[=[
+	What an entry has told us about itself so far.
+
+	Owned by `executeEntry` and written through by `runEntry`, because
+	`runEntry` can error outright and take its own locals with it — which is
+	exactly the failure that has nothing else to say. `captureInstalled` stays
+	nil until the tap is attempted, so a package that failed before then reports
+	no answer rather than a wrong one.
+]=]
+type EntryProgress = {
+	captureInstalled: boolean?,
+	phase: string,
+}
+
 type StreamingSummary = {
 	pkg: string,
 	project: string,
@@ -188,7 +203,8 @@ end
 local function runEntry(
 	callingScript: LuaSourceContainer,
 	entry: EntryPayload,
-	publishProgress: TestProgress.Publish?
+	publishProgress: TestProgress.Publish?,
+	progress: EntryProgress
 ): (boolean, string, SnapshotWrites?, string?, boolean)
 	local t0 = os.clock()
 	local timingEnabled = entry.config.runnerTiming == true
@@ -196,6 +212,7 @@ local function runEntry(
 	-- Absent means the host asked for no budget.
 	local budgetMs = entry.config.runnerTimeoutMs
 
+	progress.phase = "resolveJest"
 	local t_findJest0 = os.clock()
 	local JestModule = InstanceResolver.getJest(entry.config)
 	local t_findJest = os.clock()
@@ -219,16 +236,11 @@ local function runEntry(
 	-- (e.g. "No tests found, exiting with code 1") are captured into the
 	-- BANNER OUTPUT buffer. Single-package mode (runner.luau) does the same.
 	local capturedMessages: { CapturedMessage } = {}
-	local restoreStdout: (() -> ())?
-	local restoreStderr: (() -> ())?
-	pcall(function()
-		local nodeModules = JestModule.Parent.Parent.Parent :: any
-		local RobloxShared = (require :: any)(nodeModules["@rbxts-js"].RobloxShared)
-		local process = RobloxShared.nodeUtils.process
-
-		restoreStdout = InterceptWriteable.intercept(process.stdout, capturedMessages, 0)
-		restoreStderr = InterceptWriteable.intercept(process.stderr, capturedMessages, 1)
-	end)
+	local restoreCapture = ProcessCapture.install(JestModule, capturedMessages)
+	-- Recorded either way: an entry that comes back with an exit code and no
+	-- banner output reads differently depending on whether Jest wrote nothing
+	-- or nobody was listening, and only this call knows which.
+	progress.captureInstalled = restoreCapture ~= nil
 
 	-- ALL post-patch work (require, project/setup resolution, runCLI) must
 	-- be inside this guard so SnapshotPatch.unpatch always runs. If require
@@ -247,6 +259,7 @@ local function runEntry(
 		local Jest = (require :: any)(JestModule)
 		local t_requireJest = os.clock()
 
+		progress.phase = "resolveProjects"
 		local t_resolveProjects0 = os.clock()
 		local projectInstances = {}
 		if entry.config.projects then
@@ -274,6 +287,7 @@ local function runEntry(
 			entry.config.setupFilesAfterEnv :: any
 		)
 
+		progress.phase = "run"
 		-- Per-package isolation: the shared helper resets the global probe
 		-- sink here, immediately before Jest.runCLI, so the captured map only
 		-- contains hits from this package's instrumented sources — and installs
@@ -333,11 +347,8 @@ local function runEntry(
 		timeoutMs = budgetMs,
 	})
 
-	if restoreStdout then
-		restoreStdout()
-	end
-	if restoreStderr then
-		restoreStderr()
+	if restoreCapture then
+		restoreCapture()
 	end
 
 	SetupTiming.unpatch(setupTimingState)
@@ -468,6 +479,10 @@ local function executeEntry(
 ): (ResultEntry, string?)
 	local t0 = os.clock()
 	local changingPackage = entry.pkg ~= prevPkg
+	-- Opened here so a failure before `runEntry` is reached still names the
+	-- phase it happened in, and handed on so one that kills `runEntry` outright
+	-- reports how far that call got.
+	local progress: EntryProgress = { phase = "staging" }
 
 	-- Wrap the staging hand-off so a missing/torn-down `__pkg_stage` (or any
 	-- materialize-side assertion) surfaces as a per-pkg envelope failure
@@ -500,7 +515,7 @@ local function executeEntry(
 			project = entry.project,
 			elapsedMs = elapsedMs,
 			jestOutput = HttpService:JSONEncode(
-				RunnerResult.fail(PromiseError.normalize(stageErr))
+				RunnerResult.fail(PromiseError.normalize(stageErr), { phase = progress.phase })
 			),
 			gameOutput = stopCapture(),
 		}
@@ -508,7 +523,7 @@ local function executeEntry(
 	end
 
 	local pcallOk, jestSuccess, primary, snapshotWrites, bannerOutput, timedOut =
-		pcall(runEntry, callingScript, entry, publishProgress)
+		pcall(runEntry, callingScript, entry, publishProgress, progress)
 	local elapsedMs = math.floor((os.clock() - t0) * 1000)
 
 	-- Torn down here rather than at the next entry's materialize: the run this
@@ -534,7 +549,10 @@ local function executeEntry(
 			project = entry.project,
 			elapsedMs = elapsedMs,
 			jestOutput = HttpService:JSONEncode(
-				RunnerResult.fail(PromiseError.normalize(jestSuccess))
+				RunnerResult.fail(PromiseError.normalize(jestSuccess), {
+					captureInstalled = progress.captureInstalled,
+					phase = progress.phase,
+				})
 			),
 			gameOutput = gameOutput,
 		}
@@ -554,7 +572,11 @@ local function executeEntry(
 			project = entry.project,
 			elapsedMs = elapsedMs,
 			jestOutput = HttpService:JSONEncode(
-				RunnerResult.fail(primary, { abandon = if abandoned then "timeout" else nil })
+				RunnerResult.fail(primary, {
+					abandon = if abandoned then "timeout" else nil,
+					captureInstalled = progress.captureInstalled,
+					phase = progress.phase,
+				})
 			),
 			gameOutput = gameOutput,
 			bannerOutput = bannerOutput,

--- a/skills/jest-roblox-cli/references/debugging.md
+++ b/skills/jest-roblox-cli/references/debugging.md
@@ -21,6 +21,7 @@
 | "Execution timed out"                                            | Test exceeded timeout                                  | Increase `--timeout` value; on Open Cloud the error also names the last test the runtime reached (see below)                                           |
 | "Execution was cancelled"                                        | Task cancelled externally                              | Check Roblox Open Cloud dashboard                                                                                                                      |
 | "Studio plugin disconnected before sending results"              | Studio closed mid-run                                  | Keep Studio open during test execution                                                                                                                 |
+| "Jest exited before returning a result"                          | The run exited writing no cause anywhere it was heard  | Read the report under it — see below                                                                                                                   |
 
 ## A run that wedged
 
@@ -55,6 +56,43 @@ the task that wrote it.
 
 Nothing here fails a run on its own: a key without the `memory-store.sorted-map`
 scopes simply reports the bare timeout.
+
+## A run that came back with only an exit code
+
+Jest exits through a shim that raises `Exited with code: N`, and the reason it
+exited is written to `process.stdout` a moment earlier. The runners tap that
+stream into Banner Output and surface it as the failure. When the tap caught
+nothing there is no cause to show, and the failure reports what the host knows
+instead:
+
+```text
+  FAIL  <exec-error>
+Test suite failed to run
+
+Jest exited before returning a result, and no cause was captured.
+
+  Project      @scope/pkg › unit
+  Phase        running Jest
+  Test files   1 selected by the host
+  Capture      stdout/stderr intercepted; Jest wrote nothing
+  Game Output  14 lines captured; the last of them follow
+
+    ...
+
+Exited with code: 1
+```
+
+Read it row by row. **Phase** says how far the run got —
+`staging the package into the DataModel`, `resolving the Jest module`,
+`resolving project and setup-file instances`, or `running Jest`. **Test files**
+is the host's own selection: zero there and an exit of 1 is the
+`passWithNoTests` shape, but the report will not say so, because several other
+failures exit the same way. **Capture** distinguishes a Jest that wrote nothing
+from a tap that never went on; the latter is a fault in this CLI, not in the
+project under test. **Game Output** is the wider LogService dump — an
+intercepted `process.stdout` still delegates to `print`, so the line Jest exited
+on usually appears in its tail even when Banner Output is empty.
+`--gameOutput <path>` writes all of it.
 
 ## Diagnostic Flags
 

--- a/src/executor.spec.ts
+++ b/src/executor.spec.ts
@@ -3156,12 +3156,13 @@ describe(runProjectsAsync, () => {
 			);
 		});
 
-		it("should fall back to the raw error message when bannerOutput entries are all blank", async () => {
-			expect.assertions(1);
+		it("should fall back to the host's own report when bannerOutput entries are all blank", async () => {
+			expect.assertions(2);
 
 			// Edge case: bannerOutput parses to entries but every message is
 			// whitespace/empty. Don't compose a "(blank)\n\nExited with..."
-			// monstrosity — just use the exit-code message.
+			// monstrosity — report what the host knows and keep the exit code
+			// as the footer.
 			const backendResult: BackendResult = {
 				rawResults: [
 					{
@@ -3186,7 +3187,74 @@ describe(runProjectsAsync, () => {
 				version: "0.0.0-test",
 			});
 
-			expect(results[0]!.result.testResults[0]!.failureMessage).toBe("Exited with code: 1");
+			const failureMessage = results[0]!.result.testResults[0]!.failureMessage!;
+
+			expect(failureMessage).toStartWith(
+				"Jest exited before returning a result, and no cause was captured.",
+			);
+			expect(failureMessage).toEndWith("Exited with code: 1");
+		});
+
+		// The job the host dispatched is the one thing a run that came back
+		// with nothing cannot take away, so the report is built from it.
+		it("should name the package, project and selected test files the host dispatched", async () => {
+			expect.assertions(2);
+
+			const backendResult: BackendResult = {
+				rawResults: [{ entry: { jestOutput: failureEnvelope } }],
+				timing: DEFAULT_TIMING,
+			};
+
+			const { results } = await runProjectsAsync({
+				backend: backendReturning(backendResult),
+				deferFormatting: true,
+				projects: [
+					{
+						config: DEFAULT_CONFIG,
+						displayName: "unit",
+						pkg: "@scope/boom",
+						testFiles: ["src/a.spec.ts", "src/b.spec.ts"],
+					},
+				],
+				startTime: Date.now(),
+				version: "0.0.0-test",
+			});
+
+			const failureMessage = results[0]!.result.testResults[0]!.failureMessage!;
+
+			expect(failureMessage).toContain("Project      @scope/boom › unit");
+			expect(failureMessage).toContain("Test files   2 selected by the host");
+		});
+
+		it("should carry the runner's phase and capture state into the report", async () => {
+			expect.assertions(2);
+
+			const phasedFailure = JSON.stringify({
+				err: "Exited with code: 1",
+				runner: { captureInstalled: false, phase: "resolveJest" },
+				success: false,
+			});
+			const backendResult: BackendResult = {
+				rawResults: [{ entry: { jestOutput: phasedFailure } }],
+				timing: DEFAULT_TIMING,
+			};
+
+			const { results } = await runProjectsAsync({
+				backend: backendReturning(backendResult),
+				deferFormatting: true,
+				projects: [
+					{ config: DEFAULT_CONFIG, displayName: "boom", testFiles: ["src/b.spec.ts"] },
+				],
+				startTime: Date.now(),
+				version: "0.0.0-test",
+			});
+
+			const failureMessage = results[0]!.result.testResults[0]!.failureMessage!;
+
+			expect(failureMessage).toContain("Phase        resolving the Jest module");
+			expect(failureMessage).toContain(
+				"Capture      stdout/stderr interception could not be installed",
+			);
 		});
 
 		// When Jest's exit(1) fires for "no tests found", the underlying

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -477,6 +477,14 @@ function processOrRecoverEntry(
 			backendTiming: context.backendTiming,
 			config: job.config,
 			deferFormatting: context.deferFormatting,
+			// Off the job rather than off the entry: the entry is what the run
+			// came back with, and a run that came back with nothing still has
+			// the job the host sent.
+			entry: {
+				pkg: job.pkg,
+				project: job.displayName,
+				testFileCount: job.testFiles.length,
+			},
 			error: err,
 			startTime: context.startTime,
 			version: context.version,

--- a/src/executor/exec-error.spec.ts
+++ b/src/executor/exec-error.spec.ts
@@ -166,3 +166,17 @@ describe(buildExecutionErrorResult, () => {
 		},
 	);
 });
+
+// Characterization of the failure a workspace entry reports when Jest exits
+// without writing a cause anywhere the runner captured. Everything the reader
+// gets is the transport's own exit code: which package failed, how far it got,
+// and whether anything was captured at all are all absent.
+describe("an exit-code-only failure with nothing captured", () => {
+	it("should report only the transport exit code", () => {
+		expect.assertions(1);
+
+		const result = buildResult({ deferFormatting: true, message: "Exited with code: 1" });
+
+		expect(result.result.testResults[0]!.failureMessage).toBe("Exited with code: 1");
+	});
+});

--- a/src/executor/exec-error.spec.ts
+++ b/src/executor/exec-error.spec.ts
@@ -1,12 +1,13 @@
 import { fromAny } from "@total-typescript/shoehorn";
 
-import { describe, expect, it, vi } from "vitest";
+import { assert, describe, expect, it, vi } from "vitest";
 
 import type { BackendTiming } from "../backends/interface.ts";
 import type { ResolvedConfig } from "../config/schema.ts";
 import { DEFAULT_CONFIG } from "../config/schema.ts";
 import { LuauScriptError } from "../reporter/parser.ts";
 import { EXEC_ERROR_FILE_PATH } from "../types/jest-result.ts";
+import type { ExecErrorEntry } from "./exec-error.ts";
 import { buildExecutionErrorResult } from "./exec-error.ts";
 
 const BACKEND_TIMING: BackendTiming = {
@@ -14,30 +15,57 @@ const BACKEND_TIMING: BackendTiming = {
 	uploadMs: 11,
 };
 
+const ENTRY: ExecErrorEntry = { pkg: "@scope/pkg", project: "unit", testFileCount: 3 };
+
 function buildResult({
 	bannerOutput,
+	captureInstalled,
 	deferFormatting,
+	entry = ENTRY,
+	gameOutput = "complete game log",
 	message = "failure",
+	phase,
 	timedOut,
 }: {
 	bannerOutput?: string | undefined;
+	captureInstalled?: boolean | undefined;
 	deferFormatting: boolean | undefined;
+	entry?: ExecErrorEntry | undefined;
+	gameOutput?: string | undefined;
 	message?: string | undefined;
+	phase?: string | undefined;
 	timedOut?: boolean | undefined;
 }) {
 	const error = new LuauScriptError(message);
 	error.bannerOutput = bannerOutput;
-	error.gameOutput = "complete game log";
+	error.captureInstalled = captureInstalled;
+	error.gameOutput = gameOutput;
+	error.phase = phase;
 	error.timedOut = timedOut;
 
 	return buildExecutionErrorResult({
 		backendTiming: BACKEND_TIMING,
 		config: fromAny<ResolvedConfig, unknown>(DEFAULT_CONFIG),
 		deferFormatting,
+		entry,
 		error,
 		startTime: 1_000,
 		version: "1.2.3",
 	});
+}
+
+function failureMessageOf(options: Parameters<typeof buildResult>[0]): string {
+	const message = buildResult(options).result.testResults[0]?.failureMessage;
+	assert(message !== undefined, "an exec-error result always carries a failureMessage");
+	return message;
+}
+
+function encodeOutput(...messages: Array<string>): string {
+	return JSON.stringify(
+		messages.map((message, index) => {
+			return { message, messageType: 0, timestamp: index };
+		}),
+	);
 }
 
 describe(buildExecutionErrorResult, () => {
@@ -152,31 +180,175 @@ describe(buildExecutionErrorResult, () => {
 		"",
 		JSON.stringify([{ message: "  ", messageType: 0, timestamp: 0 }]),
 	] as const)(
-		"should keep the exit message when banner output %j has no content",
+		"should report instead of guessing when banner output %j has no content",
 		(bannerOutput) => {
-			expect.assertions(1);
+			expect.assertions(2);
 
-			const result = buildResult({
+			const message = failureMessageOf({
 				bannerOutput,
 				deferFormatting: true,
 				message: "Exited with code: 1",
 			});
 
-			expect(result.result.testResults[0]!.failureMessage).toBe("Exited with code: 1");
+			expect(message).toStartWith(
+				"Jest exited before returning a result, and no cause was captured.",
+			);
+			expect(message).toEndWith("Exited with code: 1");
 		},
 	);
 });
 
-// Characterization of the failure a workspace entry reports when Jest exits
-// without writing a cause anywhere the runner captured. Everything the reader
-// gets is the transport's own exit code: which package failed, how far it got,
-// and whether anything was captured at all are all absent.
+// What the reader is left with when Jest exits without writing a cause
+// anywhere the runner captured. The exit code alone names none of the several
+// failures that exit this way, so the report says what the host knows for
+// certain and stops there.
 describe("an exit-code-only failure with nothing captured", () => {
-	it("should report only the transport exit code", () => {
+	it("should report every fact the host holds about the entry", () => {
 		expect.assertions(1);
+
+		const message = failureMessageOf({
+			captureInstalled: true,
+			deferFormatting: true,
+			gameOutput: encodeOutput("staging @scope/pkg", "No tests found in @scope/pkg"),
+			message: "Exited with code: 1",
+			phase: "run",
+		});
+
+		expect(message).toBe(
+			[
+				"Jest exited before returning a result, and no cause was captured.",
+				"",
+				"  Project      @scope/pkg › unit",
+				"  Phase        running Jest",
+				"  Test files   3 selected by the host",
+				"  Capture      stdout/stderr intercepted; Jest wrote nothing",
+				"  Game Output  2 lines captured; the last of them follow",
+				"",
+				"    staging @scope/pkg",
+				"    No tests found in @scope/pkg",
+				"",
+				"Exited with code: 1",
+			].join("\n"),
+		);
+	});
+
+	it("should name the project alone outside workspace mode", () => {
+		expect.assertions(1);
+
+		const message = failureMessageOf({
+			deferFormatting: true,
+			entry: { project: "unit", testFileCount: 0 },
+			message: "Exited with code: 1",
+		});
+
+		expect(message).toContain("  Project      unit\n");
+	});
+
+	it("should report a host selection of zero test files without calling it the cause", () => {
+		expect.assertions(2);
+
+		const message = failureMessageOf({
+			deferFormatting: true,
+			entry: { pkg: "@scope/pkg", project: "unit", testFileCount: 0 },
+			message: "Exited with code: 1",
+		});
+
+		expect(message).toContain("  Test files   0 selected by the host\n");
+		expect(message).not.toContain("No tests found");
+	});
+
+	it.for([
+		["staging", "staging the package into the DataModel"],
+		["resolveJest", "resolving the Jest module"],
+		["resolveProjects", "resolving project and setup-file instances"],
+		["run", "running Jest"],
+	] as const)("should render the %j phase in words", ([phase, label]) => {
+		expect.assertions(1);
+
+		const message = failureMessageOf({
+			deferFormatting: true,
+			message: "Exited with code: 1",
+			phase,
+		});
+
+		expect(message).toContain(`  Phase        ${label}\n`);
+	});
+
+	it("should render a phase this version has no wording for as itself", () => {
+		expect.assertions(1);
+
+		const message = failureMessageOf({
+			deferFormatting: true,
+			message: "Exited with code: 1",
+			phase: "somethingNewer",
+		});
+
+		expect(message).toContain("  Phase        somethingNewer\n");
+	});
+
+	it.for([
+		[undefined, "the runner does not report whether stdout/stderr was intercepted"],
+		[true, "stdout/stderr intercepted; Jest wrote nothing"],
+		[false, "stdout/stderr interception could not be installed"],
+	] as const)("should tell a capture of %j apart from the others", ([captureInstalled, note]) => {
+		expect.assertions(1);
+
+		const message = failureMessageOf({
+			captureInstalled,
+			deferFormatting: true,
+			message: "Exited with code: 1",
+		});
+
+		expect(message).toContain(`  Capture      ${note}\n`);
+	});
+
+	it("should keep the Game Output tail to its last lines", () => {
+		expect.assertions(3);
+
+		const message = failureMessageOf({
+			deferFormatting: true,
+			gameOutput: encodeOutput("one", "two", "three", "four", "five", "six", "seven"),
+			message: "Exited with code: 1",
+		});
+
+		expect(message).toContain("  Game Output  7 lines captured; the last of them follow\n");
+		expect(message).not.toContain("    two\n");
+		expect(message).toContain("    three\n    four\n    five\n    six\n    seven\n");
+	});
+
+	it("should drop blank Game Output lines from the tail", () => {
+		expect.assertions(2);
+
+		const message = failureMessageOf({
+			deferFormatting: true,
+			gameOutput: encodeOutput(" ".repeat(3), "the last thing said"),
+			message: "Exited with code: 1",
+		});
+
+		expect(message).toContain("    the last thing said\n");
+		expect(message).not.toContain("       \n");
+	});
+
+	it("should say so when the Game Output holds nothing to show", () => {
+		expect.assertions(2);
+
+		const message = failureMessageOf({
+			deferFormatting: true,
+			gameOutput: encodeOutput("  "),
+			message: "Exited with code: 1",
+		});
+
+		expect(message).toContain("  Game Output  nothing captured");
+		expect(message).toEndWith("nothing captured\n\nExited with code: 1");
+	});
+
+	it("should still report a failed file carrying no failed tests", () => {
+		expect.assertions(3);
 
 		const result = buildResult({ deferFormatting: true, message: "Exited with code: 1" });
 
-		expect(result.result.testResults[0]!.failureMessage).toBe("Exited with code: 1");
+		expect(result.result.success).toBeFalse();
+		expect(result.result.numFailedTests).toBe(0);
+		expect(result.result.testResults[0]!.testResults).toBeEmpty();
 	});
 });

--- a/src/executor/exec-error.ts
+++ b/src/executor/exec-error.ts
@@ -1,19 +1,38 @@
 import type { BackendTiming } from "../backends/interface.ts";
 import type { ResolvedConfig } from "../config/schema.ts";
 import type { LuauScriptError } from "../reporter/parser.ts";
+import type { GameOutputEntry } from "../types/game-output.ts";
 import { EXEC_ERROR_FILE_PATH } from "../types/jest-result.ts";
 import type { JestResult } from "../types/jest-result.ts";
 import type { TimingResult } from "../types/timing.ts";
+import { composeEntryDisplayName } from "../utils/display-name.ts";
 import { parseGameOutput } from "../utils/game-output.ts";
 import { formatExecuteOutput } from "./format-output.ts";
 import type { ExecuteResult } from "./types.ts";
 
 const EXIT_CODE_MESSAGE = /^Exited with code: \d+$/;
 
+/**
+ * What the host knows about the entry a failure came back on, before anything
+ * the runtime captured is read.
+ *
+ * This is the half of a failure that survives a run which produced no output
+ * at all, so it is what the report falls back to rather than leaving the
+ * reader with a bare exit code.
+ */
+export interface ExecErrorEntry {
+	/** Workspace mode only: the package that owns the project. */
+	pkg?: string | undefined;
+	project: string;
+	/** How many test files the host selected for this entry. */
+	testFileCount: number;
+}
+
 export interface ExecutionErrorOptions {
 	backendTiming: BackendTiming;
 	config: ResolvedConfig;
 	deferFormatting: boolean | undefined;
+	entry: ExecErrorEntry;
 	error: LuauScriptError;
 	startTime: number;
 	version: string;
@@ -29,11 +48,12 @@ export function buildExecutionErrorResult({
 	backendTiming,
 	config,
 	deferFormatting,
+	entry,
 	error,
 	startTime,
 	version,
 }: ExecutionErrorOptions): ExecuteResult {
-	const result = buildExecErrorJestResult(error, startTime);
+	const result = buildExecErrorJestResult(error, entry, startTime);
 	const timing = buildErrorTiming(backendTiming, startTime);
 
 	const output =
@@ -48,49 +68,154 @@ export function buildExecutionErrorResult({
 	};
 }
 
+// How the phases the Luau runners name read to someone who has never opened
+// them. An id with no entry here renders as itself: a runner that grows a
+// phase then says something truer than "unknown" would, even before this map
+// catches up with it.
+const PHASE_LABELS: Record<string, string> = {
+	resolveJest: "resolving the Jest module",
+	resolveProjects: "resolving project and setup-file instances",
+	run: "running Jest",
+	staging: "staging the package into the DataModel",
+};
+
+// Enough trailing Game Output to carry the line Jest printed on its way out —
+// an intercepted `process.stdout` still delegates to `print`, so LogService
+// sees it too — without pasting a whole run's log into a failure message.
+const GAME_OUTPUT_TAIL = 5;
+
+const LABEL_WIDTH = 13;
+
+/**
+ * The captured cause, or undefined when there is none to lead with.
+ *
+ * Banner Output (Jest's process.stdout) is where the exit cause lives —
+ * "No tests found, exiting with code 1" is written via Jest's reporter, not
+ * via the native print/warn that only LogService would capture.
+ */
+function bannerCause(error: LuauScriptError): string | undefined {
+	const entries = parseGameOutput(error.bannerOutput);
+	if (entries.length === 0) {
+		return undefined;
+	}
+
+	const lines = entries
+		.map((banner) => banner.message)
+		.join("\n")
+		.trim();
+	return lines === "" ? undefined : lines;
+}
+
+function phaseLabel(phase: string | undefined): string {
+	if (phase === undefined) {
+		return "not reported by the runner";
+	}
+
+	return PHASE_LABELS[phase] ?? phase;
+}
+
+function captureNote({ captureInstalled }: LuauScriptError): string {
+	if (captureInstalled === undefined) {
+		return "the runner does not report whether stdout/stderr was intercepted";
+	}
+
+	return captureInstalled
+		? "stdout/stderr intercepted; Jest wrote nothing"
+		: "stdout/stderr interception could not be installed";
+}
+
+function gameOutputNote(entryCount: number): string {
+	return `${String(entryCount)} lines captured; the last of them follow`;
+}
+
+/**
+ * The trailing Game Output lines, blank ones dropped.
+ *
+ * Offered as what they are — the end of the log, not the cause — because the
+ * capture window closes on the package's teardown, so the very last line is as
+ * likely to be a stage reset as the message Jest exited on.
+ */
+function gameOutputTail(entries: Array<GameOutputEntry>): Array<string> {
+	const lines: Array<string> = [];
+	const tail = entries.slice(-GAME_OUTPUT_TAIL);
+	for (const entry of tail) {
+		const trimmed = entry.message.trim();
+		if (trimmed !== "") {
+			lines.push(trimmed);
+		}
+	}
+
+	return lines;
+}
+
+/**
+ * What the host can say about a failure that captured no cause of its own.
+ *
+ * Every row is a fact the host holds however little the run produced, so this
+ * reports rather than concludes: an exit code alone does not say the run found
+ * no tests, and naming one cause out of the several that exit this way would
+ * send the reader after the wrong one.
+ */
+function buildDiagnosticReport(error: LuauScriptError, entry: ExecErrorEntry): string {
+	const gameEntries = parseGameOutput(error.gameOutput);
+	const tail = gameOutputTail(gameEntries);
+
+	const rows: Array<[label: string, value: string]> = [
+		["Project", composeEntryDisplayName(entry.pkg, entry.project)],
+		["Phase", phaseLabel(error.phase)],
+		["Test files", `${String(entry.testFileCount)} selected by the host`],
+		["Capture", captureNote(error)],
+		["Game Output", tail.length > 0 ? gameOutputNote(gameEntries.length) : "nothing captured"],
+	];
+
+	const lines = [
+		"Jest exited before returning a result, and no cause was captured.",
+		"",
+		...rows.map(([label, value]) => `  ${label.padEnd(LABEL_WIDTH)}${value}`),
+	];
+
+	if (tail.length > 0) {
+		lines.push("", ...tail.map((line) => `    ${line}`));
+	}
+
+	return lines.join("\n");
+}
+
 /**
  * Compose the human-readable failure message for an exec-error file
  * synthesized from a Luau script failure.
  *
  * When the wire-level error is just `Exited with code: N`, the actual
  * Jest cause (`No tests found`, `passWithNoTests` guidance, etc.) lives
- * in the captured game output, not the rejection message itself. The
+ * in the captured banner output, not the rejection message itself. The
  * existing single-mode CLI banner (`cli.ts#formatLuauErrorBanner`)
  * surfaces that game output as the primary content for exit-code-only
  * errors; mirror the same semantics here so workspace-mode and
  * multi-project recovery don't drop the user-actionable cause.
  *
- * Format: meaningful game-output lines first, then a blank line, then
- * the raw exit-code message as a footer. `cleanExecErrorMessage`
- * (formatter.ts/agent.ts) takes the first non-empty content line so the
- * meaningful cause surfaces in human/agent formatters; JSON formatter
- * preserves the full multi-line text for structured consumers.
+ * Format: the captured cause first, then a blank line, then the raw exit-code
+ * message as a footer. When nothing was captured there is no cause to lead
+ * with, and the report the host can always build takes that place instead —
+ * see {@link buildDiagnosticReport}.
  */
-function composeExecErrorMessage(error: LuauScriptError): string {
+function composeExecErrorMessage(error: LuauScriptError, entry: ExecErrorEntry): string {
 	if (!EXIT_CODE_MESSAGE.test(error.message)) {
 		return error.message;
 	}
 
-	// Banner Output (Jest's process.stdout) is where the exit cause lives —
-	// "No tests found, exiting with code 1" is written via Jest's reporter,
-	// not via native print/warn that LogService would capture.
-	const entries = parseGameOutput(error.bannerOutput);
-	if (entries.length === 0) {
-		return error.message;
+	const cause = bannerCause(error);
+	if (cause !== undefined) {
+		return `${cause}\n\n${error.message}`;
 	}
 
-	const gameLines = entries
-		.map((entry) => entry.message)
-		.join("\n")
-		.trim();
-	if (gameLines === "") {
-		return error.message;
-	}
-
-	return `${gameLines}\n\n${error.message}`;
+	return `${buildDiagnosticReport(error, entry)}\n\n${error.message}`;
 }
 
-function buildExecErrorJestResult(error: LuauScriptError, startTime: number): JestResult {
+function buildExecErrorJestResult(
+	error: LuauScriptError,
+	entry: ExecErrorEntry,
+	startTime: number,
+): JestResult {
 	// Exec-error file shape (see `hasExecError`): `failureMessage` set with
 	// empty `testResults` — the file errored before any tests ran, so
 	// `numFailingTests`/`numFailedTests`/`numTotalTests` all stay 0.
@@ -105,7 +230,7 @@ function buildExecErrorJestResult(error: LuauScriptError, startTime: number): Je
 		success: false,
 		testResults: [
 			{
-				failureMessage: composeExecErrorMessage(error),
+				failureMessage: composeExecErrorMessage(error, entry),
 				numFailingTests: 0,
 				numPassingTests: 0,
 				numPendingTests: 0,

--- a/src/formatters/failure.ts
+++ b/src/formatters/failure.ts
@@ -220,11 +220,14 @@ export function formatExecErrorDetail(
 	const badge =
 		file.timedOut === true ? styles.timeoutBadge(" TIMEOUT ") : styles.failBadge(" FAIL ");
 
+	// Indented line by line rather than as one block: the message can be a
+	// multi-line report, and indenting only its first line would leave the rest
+	// hanging off the left margin the whole failure block is drawn against.
 	const lines: Array<string> = [
 		`  ${badge} ${styles.status.fail(displayPath)}`,
 		`  ${styles.status.fail(execErrorTitle(file))}`,
 		"",
-		`  ${styles.status.fail(errorMessage)}`,
+		...indentMessage(errorMessage, styles),
 	];
 
 	const hint = getExecErrorHint(errorMessage);
@@ -322,4 +325,10 @@ function formatFailureMessage(
 			useColor,
 		}),
 	];
+}
+
+// Two spaces on every content line; a blank one is left alone so the block
+// carries neither trailing whitespace nor colour codes wrapping nothing.
+function indentMessage(message: string, styles: Styles): Array<string> {
+	return message.split("\n").map((line) => (line === "" ? "" : `  ${styles.status.fail(line)}`));
 }

--- a/src/reporter/parser.spec.ts
+++ b/src/reporter/parser.spec.ts
@@ -1831,18 +1831,20 @@ describe("promise trace boundaries", () => {
 	});
 });
 
-describe("abandon reason", () => {
-	function thrownFrom(output: string): LuauScriptError {
-		try {
-			parseJestOutput(output);
-		} catch (err) {
-			assert(err instanceof LuauScriptError);
-			return err;
-		}
-
-		throw new Error("expected the envelope to throw");
+// The failure a `{success:false, err}` envelope throws, for the dimensions
+// that only ever ride on one.
+function thrownFrom(output: string): LuauScriptError {
+	try {
+		parseJestOutput(output);
+	} catch (err) {
+		assert(err instanceof LuauScriptError);
+		return err;
 	}
 
+	throw new Error("expected the envelope to throw");
+}
+
+describe("abandon reason", () => {
 	it("should mark a run the runner abandoned at its budget", () => {
 		expect.assertions(2);
 
@@ -1878,5 +1880,39 @@ describe("abandon reason", () => {
 
 		expect(error.timedOut).toBeUndefined();
 		expect(error.message).toBe("boom");
+	});
+});
+
+describe("the phase and capture state a failed run reports", () => {
+	function failureWith(runner: unknown): string {
+		return JSON.stringify({ err: "Exited with code: 1", runner, success: false });
+	}
+
+	it("should carry the phase the runner named", () => {
+		expect.assertions(1);
+
+		expect(thrownFrom(failureWith({ phase: "runCLI" })).phase).toBe("runCLI");
+	});
+
+	// Same leniency the abandon reason gets: a producer that drifts drops the
+	// dimension rather than reporting a phase spelled as nothing at all.
+	it.for([undefined, "", 7] as const)("should drop a phase of %j", (phase) => {
+		expect.assertions(1);
+
+		expect(thrownFrom(failureWith({ phase })).phase).toBeUndefined();
+	});
+
+	it.for([true, false] as const)("should carry a capture state of %j", (captureInstalled) => {
+		expect.assertions(1);
+
+		expect(thrownFrom(failureWith({ captureInstalled })).captureInstalled).toBe(
+			captureInstalled,
+		);
+	});
+
+	it.for([undefined, "yes"] as const)("should drop a capture state of %j", (captureInstalled) => {
+		expect.assertions(1);
+
+		expect(thrownFrom(failureWith({ captureInstalled })).captureInstalled).toBeUndefined();
 	});
 });

--- a/src/reporter/parser.ts
+++ b/src/reporter/parser.ts
@@ -26,11 +26,23 @@ export class LuauScriptError extends Error {
 	 */
 	public bannerOutput: string | undefined;
 	/**
+	 * Whether the runner installed its stdout/stderr interception before the
+	 * run that failed. Set from the envelope's own `runner.captureInstalled`,
+	 * and read by the exec-error report so "nothing was written" reads apart
+	 * from "nobody was listening". Undefined when the runner does not say.
+	 */
+	public captureInstalled: boolean | undefined;
+	/**
 	 * The LogService.MessageOut dump for the failed run. Propagated through
 	 * the exec-error path so `--gameOutput <path>` still receives the full
 	 * log when an entry's envelope decodes to a Luau-level script failure.
 	 */
 	public gameOutput: string | undefined;
+	/**
+	 * How far into the entry the runner got before it failed, as the Luau side
+	 * named the phase. Undefined when the runner names none.
+	 */
+	public phase: string | undefined;
 	/**
 	 * The run this failure came from was abandoned at its `projectTimeout`.
 	 * Set from the envelope's own `runner.abandon` block, and read by the
@@ -77,8 +89,10 @@ type JestEnvelope = typeof jestEnvelopeSchema.infer;
 
 const runnerFieldsSchema = type({
 	"abandon?": "unknown",
+	"captureInstalled?": "unknown",
 	"coverage?": jsonValueSchema,
 	"perTestCoverage?": "unknown",
+	"phase?": "unknown",
 	"setup?": "unknown",
 	"snapshotWrites?": "unknown",
 	"timing?": "unknown",
@@ -365,6 +379,10 @@ function unwrapResult(parsed: JestEnvelope, runner: RunnerFields): JestEnvelope 
 		// so a runner that gives up on a run says so through the shared result
 		// seam rather than through a field of its own on the envelope entry.
 		error.timedOut = runner.abandon === "timeout" ? true : undefined;
+		error.phase =
+			typeof runner.phase === "string" && runner.phase !== "" ? runner.phase : undefined;
+		error.captureInstalled =
+			typeof runner.captureInstalled === "boolean" ? runner.captureInstalled : undefined;
 		throw error;
 	}
 

--- a/src/reporter/streaming-progress.ts
+++ b/src/reporter/streaming-progress.ts
@@ -1,6 +1,7 @@
 import color from "tinyrainbow";
 
 import type { StreamingResultEntry } from "../memory-store/sorted-map-client.ts";
+import { composeEntryDisplayName } from "../utils/display-name.ts";
 
 export interface ProgressLineOptions {
 	color: boolean;
@@ -52,5 +53,5 @@ function formatBreakdown(entry: StreamingResultEntry, isColorEnabled: boolean): 
 }
 
 function formatLabel(entry: StreamingResultEntry): string {
-	return entry.pkg === entry.project ? entry.pkg : `${entry.pkg} › ${entry.project}`;
+	return composeEntryDisplayName(entry.pkg, entry.project);
 }

--- a/src/run/workspace.ts
+++ b/src/run/workspace.ts
@@ -21,6 +21,7 @@ import { NOOP_RUN_PROGRESS, type RunProgress } from "../progress/reporter.ts";
 import type { StreamingAggregatorOnEntry } from "../reporter/streaming-aggregator.ts";
 import { formatStreamingProgressLine } from "../reporter/streaming-progress.ts";
 import type { TimingCollector } from "../timing/orchestration-collector.ts";
+import { composeEntryDisplayName } from "../utils/display-name.ts";
 import {
 	runWorkspaceAsync,
 	type WorkspaceProjectResult,
@@ -385,10 +386,6 @@ function resolveReportOptions(
 	};
 }
 
-function composeWorkspaceDisplayName(packageName: string, project: string): string {
-	return packageName === project ? packageName : `${packageName} › ${project}`;
-}
-
 // Counted in packages, not project rows: one package can own several projects,
 // and "after 3 packages" reading as 3 when only one package ran would misreport
 // how far the run got.
@@ -427,7 +424,7 @@ function buildWorkspaceResult({
 
 	const projectResults: Array<ProjectResult> = results.map((entry) => {
 		return {
-			displayName: composeWorkspaceDisplayName(entry.pkg, entry.displayName),
+			displayName: composeEntryDisplayName(entry.pkg, entry.displayName),
 			result: entry.result,
 		};
 	});

--- a/src/utils/display-name.ts
+++ b/src/utils/display-name.ts
@@ -1,0 +1,14 @@
+/**
+ * The one spelling of an entry's identity: the package that owns it, then the
+ * project inside it.
+ *
+ * A project collapses to its own name when nothing distinguishes the two —
+ * either the run has no packages (single-package and multi mode) or the
+ * package publishes one project under its own name. Repeating the name either
+ * side of the separator would read as two things where there is one.
+ */
+export function composeEntryDisplayName(packageName: string | undefined, project: string): string {
+	return packageName === undefined || packageName === project
+		? project
+		: `${packageName} › ${project}`;
+}

--- a/test/luau/embedded-runner.harness.luau
+++ b/test/luau/embedded-runner.harness.luau
@@ -212,6 +212,11 @@ local materializeFails = {}
 local jestFails = {}
 local jestRedTests = {}
 local jestMissing = {}
+-- What a package writes to Jest's own stdout on its way out, the way the real
+-- "No tests found, exiting with code 1" is written.
+local jestBanners = {}
+-- Stands the RobloxShared package down, so the output tap cannot be installed.
+local sharedIsMissing = false
 local silent = {}
 local jestHangs = {}
 -- Parks the way a slow package does — no warning, nothing wrong, just still
@@ -258,6 +263,22 @@ local CircusStateModule = makeInstance("state")
 local CircusModule =
 	makeInstance("JestCircus", { circus = makeInstance("circus", { state = CircusStateModule }) })
 local ExpectModule = makeInstance("Expect")
+local RobloxSharedModule = makeInstance("RobloxShared")
+
+-- Shaped like @rbxts-js/roblox-shared's Writeable: a _writeFn the tap swaps
+-- out, defaulting to the print that puts the same line in Game Output.
+local function makeWriteable(): any
+	local writeable = { _writeFn = print }
+	function writeable:write(data: string)
+		self._writeFn(data)
+	end
+
+	return writeable
+end
+
+local RobloxSharedExports = {
+	nodeUtils = { process = { stderr = makeWriteable(), stdout = makeWriteable() } },
+}
 local RuntimeModule = makeInstance("JestRuntime")
 local Jest = {
 	runCLI = function(_, config)
@@ -267,6 +288,11 @@ local Jest = {
 				jestSawConfig = config
 				say(pkg, "jest:" .. pkg, OUTPUT)
 				say(pkg, "warn:" .. pkg, WARNING)
+				local banner = jestBanners[pkg]
+				if banner then
+					RobloxSharedExports.nodeUtils.process.stdout:write(banner)
+				end
+
 				if jestFails[pkg] then
 					error("jest exploded in " .. pkg, 0)
 				end
@@ -316,17 +342,15 @@ local stubs = {
 		findInstance = function(path)
 			return path
 		end,
+		findRobloxShared = function()
+			return if sharedIsMissing then nil else RobloxSharedModule
+		end,
 		findSiblingPackage = function(_module, name)
 			if name == "JestCircus" then
 				return CircusModule
 			end
 
 			return if name == "JestRuntime" then RuntimeModule else ExpectModule
-		end,
-	},
-	["../intercept-writeable"] = {
-		intercept = function()
-			return function() end
 		end,
 	},
 	["./materializer"] = {
@@ -404,6 +428,10 @@ local function require(target)
 		return { addEventHandler = function() end }
 	end
 
+	if target == RobloxSharedModule then
+		return RobloxSharedExports
+	end
+
 	if target == ExpectModule then
 		return {
 			getState = function()
@@ -421,9 +449,17 @@ local function require(target)
 	return stub
 end
 
+-- The real tap and the real installer that reaches for it, so what a package
+-- writes to Jest's stdout here reaches Banner Output the way it does in a run —
+-- and a tree the installer cannot find RobloxShared in fails here the same way.
+-- Assigned before the modules that require it are inlined below: each of those
+-- bodies runs where it is written.
+stubs["../intercept-writeable"] = __INTERCEPT_WRITEABLE_MODULE__
+stubs["./intercept-writeable"] = stubs["../intercept-writeable"]
+stubs["./instance-resolver"] = stubs["../instance-resolver"]
+stubs["../process-capture"] = __PROCESS_CAPTURE_MODULE__
 -- The real capture module, so the window under test is the one production
 -- runs. Its own `require("./intercept-writeable")` only wants the type.
-stubs["./intercept-writeable"] = stubs["../intercept-writeable"]
 stubs["../game-output-capture"] = __CAPTURE_MODULE__
 -- The real bail module too: it decides when a loop stops taking packages,
 -- which is what the bail assertions below are about.
@@ -431,8 +467,8 @@ stubs["./bail"] = __BAIL_MODULE__
 -- The real result builder as well: it is the seam both runners assemble their
 -- `runner` envelope through, so a workspace run must reach the same fields a
 -- multi run does. Its instance-resolver sits at the luau root, not beside the
--- staging runner, so it asks under a different path than the runner does.
-stubs["./instance-resolver"] = stubs["../instance-resolver"]
+-- staging runner, so it asks under the path aliased above rather than the one
+-- the staging runner asks under.
 stubs["./test-progress"] = stubs["../test-progress"]
 stubs["../runner-result"] = __RUNNER_RESULT_MODULE__
 -- The real watchdog too: what it does to a package that parks is the subject of
@@ -540,7 +576,8 @@ end
 -- T1: the capture opens before the package is materialized and spans its run,
 -- and two packages that each print distinct messages get only their own —
 -- including the reset between them, which belongs to neither capture.
-local function testWindowAndNoBleedAcrossPackages()
+local function 
+testWindowAndNoBleedAcrossPackages()
 	local results = run({ "a", "b" })
 	local a = messagesOf(results[1])
 	local b = messagesOf(results[2])
@@ -1011,6 +1048,88 @@ local function testRefusedRequeueIsRetried()
 	check(#removedReads == 3, "T25: the read is settled once the put-back lands")
 	check(#taskWaits == 2, "T25: it waited between attempts rather than hammering")
 	check(taskWaits[2] > taskWaits[1], "T25: and backed off further each time")
+end
+
+-- T26: a failure names the phase it happened in. The three failure paths stop
+-- at three different points, and a report built on an exit code alone cannot
+-- tell them apart.
+local PHASE_CASES = {
+	{ flags = materializeFails, pkg = "c", phase = "staging", label = "stage failure" },
+	{ flags = jestMissing, pkg = "e", phase = "resolveJest", label = "runner failure" },
+	{ flags = jestFails, pkg = "d", phase = "run", label = "Jest rejection" },
+}
+
+local function testFailuresNameTheirPhase()
+	for _, case in PHASE_CASES do
+		case.flags[case.pkg] = true
+		local results = run({ case.pkg })
+		case.flags[case.pkg] = nil
+
+		local decoded = HttpService:JSONDecode(results[1].jestOutput)
+		check(decoded.runner ~= nil, "T26: " .. case.label .. " carries runner fields")
+		check(
+			decoded.runner.phase == case.phase,
+			"T26: " .. case.label .. " reports phase " .. case.phase
+		)
+	end
+end
+
+-- T27: a package that got as far as Jest says whether its stdout was being
+-- watched, so an exit code with no banner attached reads as "Jest wrote
+-- nothing" rather than as "nobody was listening".
+local function testFailureReportsWhetherOutputWasWatched()
+	jestFails.a = true
+	local watched = run({ "a" })
+	sharedIsMissing = true
+	local unwatched = run({ "a" })
+	sharedIsMissing = false
+	jestFails.a = nil
+
+	local watchedRunner = HttpService:JSONDecode(watched[1].jestOutput).runner
+	local unwatchedRunner = HttpService:JSONDecode(unwatched[1].jestOutput).runner
+	check(watchedRunner.captureInstalled == true, "T27: an installed tap is reported")
+	check(unwatchedRunner.captureInstalled == false, "T27: a tap that never went on is too")
+end
+
+-- T28: a failure before Jest is reached answers nothing about the tap, rather
+-- than answering "not installed" for a tap nothing tried to install.
+local function testFailureBeforeTheTapAnswersNothing()
+	jestMissing.e = true
+	local results = run({ "e" })
+	jestMissing.e = nil
+
+	local runner = HttpService:JSONDecode(results[1].jestOutput).runner
+	check(runner.captureInstalled == nil, "T28: an unattempted tap reports no answer")
+end
+
+-- T29: what Jest writes to its own stdout reaches Banner Output. This is where
+-- the cause of an exit lives — "No tests found, exiting with code 1" is written
+-- through process.stdout, not through the print LogService hears.
+local function testJestStdoutReachesBannerOutput()
+	jestBanners.a = "No tests found in a"
+	jestFails.a = true
+	local results = run({ "a" })
+	jestFails.a = nil
+	jestBanners.a = nil
+
+	local banner = results[1].bannerOutput
+	check(banner ~= nil, "T29: a package that wrote to stdout has Banner Output")
+	check(
+		string.find(banner, "No tests found in a", 1, true) ~= nil,
+		"T29: carrying what Jest wrote"
+	)
+end
+
+-- T30: and the tap puts it back where it found it, so the next package's
+-- capture starts empty rather than inheriting this one's.
+local function testTheTapIsPutBack()
+	jestBanners.a = "only a said this"
+	local first = run({ "a" })
+	local second = run({ "b" })
+
+	jestBanners.a = nil
+	check(first[1].bannerOutput ~= nil, "T30: the package that wrote has Banner Output")
+	check(second[1].bannerOutput == nil, "T30: the package that did not write has none")
 end
 
 testWindowAndNoBleedAcrossPackages()

--- a/test/luau/embedded-runner.spec.ts
+++ b/test/luau/embedded-runner.spec.ts
@@ -32,6 +32,14 @@ const RESULT_BUDGET_SOURCE = fs.readFileSync(
 	path.join(LUAU_DIRECTORY, "staging/result-budget.luau"),
 	"utf-8",
 );
+const INTERCEPT_WRITEABLE_SOURCE = fs.readFileSync(
+	path.join(LUAU_DIRECTORY, "intercept-writeable.luau"),
+	"utf-8",
+);
+const PROCESS_CAPTURE_SOURCE = fs.readFileSync(
+	path.join(LUAU_DIRECTORY, "process-capture.luau"),
+	"utf-8",
+);
 const HARNESS = fs.readFileSync(
 	path.join(CURRENT_DIRECTORY, "embedded-runner.harness.luau"),
 	"utf-8",
@@ -57,6 +65,14 @@ describe("embedded workspace runner under lute", () => {
 			.replace(
 				"__RESULT_BUDGET_MODULE__",
 				() => `(function()\n${RESULT_BUDGET_SOURCE}\nend)()`,
+			)
+			.replace(
+				"__INTERCEPT_WRITEABLE_MODULE__",
+				() => `(function()\n${INTERCEPT_WRITEABLE_SOURCE}\nend)()`,
+			)
+			.replace(
+				"__PROCESS_CAPTURE_MODULE__",
+				() => `(function()\n${PROCESS_CAPTURE_SOURCE}\nend)()`,
 			)
 			.replace("__MODULE__", () => `(function()\n${MODULE_SOURCE}\nend)()`);
 		const directory = fs.mkdtempSync(path.join(os.tmpdir(), "embedded-runner-"));

--- a/test/luau/runner-result.harness.luau
+++ b/test/luau/runner-result.harness.luau
@@ -378,6 +378,31 @@ local function testFailureWithoutAbandon()
 	check(payload.runner == nil, "T13: an empty dimension set attaches nothing")
 end
 
+-- T14: how far a run got and whether its output was being watched ride in that
+-- same block, so a failure that produced nothing else still says both.
+local function testPhaseAndCaptureState()
+	reset()
+	local payload = RunnerResult.fail("Exited with code: 1", {
+		captureInstalled = false,
+		phase = "run",
+	})
+
+	check(payload.runner.phase == "run", "T14: the phase reaches the wire")
+	check(payload.runner.captureInstalled == false, "T14: so does a tap that never went on")
+	check(payload.runner.abandon == nil, "T14: a run nothing abandoned names no reason")
+end
+
+-- T15: and each rides on its own, so a runner reporting one of them does not
+-- have to invent the others.
+local function testEachDimensionRidesAlone()
+	reset()
+	local phaseOnly = RunnerResult.fail("boom", { phase = "staging" })
+	local captureOnly = RunnerResult.fail("boom", { captureInstalled = true })
+
+	check(phaseOnly.runner.captureInstalled == nil, "T15: a phase alone answers nothing else")
+	check(captureOnly.runner.phase == nil, "T15: a capture state alone names no phase")
+end
+
 testBareRunHasNoRunnerKey()
 testCoverageAttachesTheSink()
 testCoverageOffAttachesNothing()
@@ -396,5 +421,7 @@ testTiming()
 testFailureEnvelope()
 testAbandonReason()
 testFailureWithoutAbandon()
+testPhaseAndCaptureState()
+testEachDimensionRidesAlone()
 
 print("ALL OK")

--- a/test/luau/runner.harness.luau
+++ b/test/luau/runner.harness.luau
@@ -132,6 +132,9 @@ local _G = {}
 local jestFails = {}
 local jestParks = {}
 local jestMissing = {}
+-- What a config writes to Jest's own stdout on its way out, the way the real
+-- "No tests found, exiting with code 1" is written.
+local jestBanners = {}
 
 -- The config Jest was last handed, so a test can tell what the runner stripped
 -- before handing it over.
@@ -157,6 +160,25 @@ local CircusModule =
 	makeInstance("JestCircus", { circus = makeInstance("circus", { state = CircusStateModule }) })
 local ExpectModule = makeInstance("Expect")
 local RuntimeModule = makeInstance("JestRuntime")
+local RobloxSharedModule = makeInstance("RobloxShared")
+
+-- Shaped like @rbxts-js/roblox-shared's Writeable: a _writeFn the tap swaps
+-- out, defaulting to the print that puts the same line in Game Output.
+local function makeWriteable(): any
+	local writeable = { _writeFn = print }
+	function writeable:write(data: string)
+		self._writeFn(data)
+	end
+
+	return writeable
+end
+
+local RobloxSharedExports = {
+	nodeUtils = { process = { stderr = makeWriteable(), stdout = makeWriteable() } },
+}
+
+-- Stands the RobloxShared package down, so the output tap cannot be installed.
+local sharedIsMissing = false
 
 local Jest = {
 	runCLI = function(_, config, projects)
@@ -165,6 +187,11 @@ local Jest = {
 			expect = function()
 				jestSawConfig = config
 				emit("jest:" .. project, OUTPUT)
+				local banner = jestBanners[project]
+				if banner then
+					RobloxSharedExports.nodeUtils.process.stdout:write(banner)
+				end
+
 				if jestFails[project] then
 					error("jest exploded in " .. project, 0)
 				end
@@ -195,17 +222,15 @@ local stubs = {
 		findInstance = function(path)
 			return path
 		end,
+		findRobloxShared = function()
+			return if sharedIsMissing then nil else RobloxSharedModule
+		end,
 		findSiblingPackage = function(_module, name)
 			if name == "JestCircus" then
 				return CircusModule
 			end
 
 			return if name == "JestRuntime" then RuntimeModule else ExpectModule
-		end,
-	},
-	["./intercept-writeable"] = {
-		intercept = function()
-			return function() end
 		end,
 	},
 	["./phase-timing"] = {
@@ -264,6 +289,10 @@ local function require(target)
 		return { addEventHandler = function() end }
 	end
 
+	if target == RobloxSharedModule then
+		return RobloxSharedExports
+	end
+
 	if target == ExpectModule then
 		return {
 			getState = function()
@@ -285,6 +314,11 @@ end
 -- production runs: the capture window and the abandon verdict are the subject
 -- of the assertions below, and the seam is where both envelope halves are
 -- decided.
+-- The real tap and the real installer that reaches for it, assigned before
+-- the modules requiring them are inlined below: each of those bodies runs
+-- where it is written.
+stubs["./intercept-writeable"] = __INTERCEPT_WRITEABLE_MODULE__
+stubs["./process-capture"] = __PROCESS_CAPTURE_MODULE__
 stubs["./game-output-capture"] = __CAPTURE_MODULE__
 stubs["./infinite-yield"] = __INFINITE_YIELD_MODULE__
 stubs["./runner-result"] = __RUNNER_RESULT_MODULE__
@@ -295,6 +329,7 @@ local function reset()
 	jestFails = {}
 	jestParks = {}
 	jestMissing = {}
+	jestBanners = {}
 	jestSawConfig = nil
 	armed = {}
 end
@@ -376,7 +411,9 @@ local function testJestRejectionIsAFailureEnvelope()
 		string.find(tostring(failed.err), "jest exploded in alpha", 1, true) ~= nil,
 		"T2: the cause travels with it"
 	)
-	check(failed.runner == nil, "T2: a run that failed on its own names no abandon reason")
+	check(failed.runner.abandon == nil, "T2: a run that failed on its own names no abandon reason")
+	check(failed.runner.phase == "run", "T2: it names the phase it failed in")
+	check(failed.runner.captureInstalled == true, "T2: and says its stdout was being watched")
 	check(outputOf(entries[2]).success == true, "T2: the batch runs on past it")
 end
 
@@ -391,6 +428,32 @@ local function testMissingJestFailsBeforeTheRun()
 	local failed = outputOf(entries[1])
 	check(failed.success == false, "T3: a config with no Jest is a failure")
 	check(has(messagesOf(entries[1]), "missing:alpha"), "T3: the lookup's warning is captured")
+	check(failed.runner.phase == "resolveJest", "T3: it names the phase it never got past")
+	check(failed.runner.captureInstalled == nil, "T3: and answers nothing about an unattempted tap")
+end
+
+-- T3b: what Jest writes to its own stdout reaches Banner Output — that is where
+-- the cause of an exit lives, written through process.stdout rather than
+-- through the print LogService hears. A tree the installer cannot find
+-- RobloxShared in says so, rather than reporting an empty capture as silence.
+local function testJestStdoutReachesBannerOutput()
+	reset()
+	jestBanners.alpha = "No tests found in alpha"
+	jestFails.alpha = true
+	local entries = Runner.runProjects({}, { configFor("alpha") })
+
+	local records = HttpService:JSONDecode(entries[1].bannerOutput)
+	check(#records == 1, "T3b: one record per write")
+	check(records[1].message == "No tests found in alpha", "T3b: carrying what Jest wrote")
+
+	sharedIsMissing = true
+	local unwatched = Runner.runProjects({}, { configFor("alpha") })
+	sharedIsMissing = false
+
+	check(
+		outputOf(unwatched[1]).runner.captureInstalled == false,
+		"T3b: a tap that never went on is reported as such"
+	)
 end
 
 -- T4: a config still running when its budget elapses is abandoned, and the
@@ -516,6 +579,7 @@ end
 testEveryConfigGetsItsOwnEntry()
 testJestRejectionIsAFailureEnvelope()
 testMissingJestFailsBeforeTheRun()
+testJestStdoutReachesBannerOutput()
 testElapsedBudgetAbandonsOnlyItsConfig()
 testWithinBudgetNamesNoReason()
 testRunnerFlagsAreStripped()

--- a/test/luau/runner.spec.ts
+++ b/test/luau/runner.spec.ts
@@ -24,6 +24,14 @@ const RUNNER_RESULT_SOURCE = fs.readFileSync(
 	path.join(LUAU_DIRECTORY, "runner-result.luau"),
 	"utf-8",
 );
+const INTERCEPT_WRITEABLE_SOURCE = fs.readFileSync(
+	path.join(LUAU_DIRECTORY, "intercept-writeable.luau"),
+	"utf-8",
+);
+const PROCESS_CAPTURE_SOURCE = fs.readFileSync(
+	path.join(LUAU_DIRECTORY, "process-capture.luau"),
+	"utf-8",
+);
 const HARNESS = fs.readFileSync(path.join(CURRENT_DIRECTORY, "runner.harness.luau"), "utf-8");
 
 describe("multi-mode runner under lute", () => {
@@ -41,6 +49,14 @@ describe("multi-mode runner under lute", () => {
 			.replace(
 				"__RUNNER_RESULT_MODULE__",
 				() => `(function()\n${RUNNER_RESULT_SOURCE}\nend)()`,
+			)
+			.replace(
+				"__INTERCEPT_WRITEABLE_MODULE__",
+				() => `(function()\n${INTERCEPT_WRITEABLE_SOURCE}\nend)()`,
+			)
+			.replace(
+				"__PROCESS_CAPTURE_MODULE__",
+				() => `(function()\n${PROCESS_CAPTURE_SOURCE}\nend)()`,
 			)
 			.replace("__MODULE__", () => `(function()\n${MODULE_SOURCE}\nend)()`);
 		const directory = fs.mkdtempSync(path.join(os.tmpdir(), "runner-"));


### PR DESCRIPTION
## Summary

A workspace entry whose Jest run exited without writing a cause came back as `Exited with code: 1` and nothing else, which names none of the several failures that exit that way.

The root cause is in the runners. Both reached for RobloxShared by walking three fixed hops up from the Jest module and indexing `@rbxts-js`, inside a `pcall` that swallowed the miss. The walk assumed the module found at `Jest` was `@rbxts/jest/src`, two levels below the node_modules folder — but `@rbxts/jest/src/init.lua` is a one-line re-export, and the ModuleScript actually named `Jest` (the one `InstanceResolver.getJest` finds) is `node_modules/@rbxts-js/Jest`, one level below it. Three hops from there lands on `rbxts_include`, which has no `@rbxts-js` child, so the stdout/stderr tap was never installed on a standard roblox-ts tree — including this repo's own live-place fixture. Banner Output was empty for every run, so the cause Jest writes on its way out had nowhere to land.

Both runners now install through `findRobloxShared`, the walk snapshot support has always used, and both report on the failure envelope whether the tap went on and which phase the run stopped in.

When there is still no captured cause, the exit code becomes the footer of a report built from what the host holds regardless of what the run produced:

```text
Jest exited before returning a result, and no cause was captured.

  Project      @scope/pkg › unit
  Phase        running Jest
  Test files   1 selected by the host
  Capture      stdout/stderr intercepted; Jest wrote nothing
  Game Output  14 lines captured; the last of them follow

    No tests found in packages/etch

Exited with code: 1
```

It reports rather than concludes: an exit code alone does not say a run found no tests, and naming one cause out of several would send the reader after the wrong one. A captured banner cause still leads where there is one, the result stays a failed file carrying zero failed tests, and the default, agent and JSON formatters report the same facts.

## Manual verification

Ran against a 12-package consumer workspace with `JEST_ROBLOX_BIN` pointed at this branch: one package alone passes, and the full workspace passes at 740 files / 6728 tests — unchanged from the released CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
